### PR TITLE
Add mobile navigation toggle

### DIFF
--- a/dars5/index.html
+++ b/dars5/index.html
@@ -169,5 +169,6 @@
 
         </footer>
 
+    <script src="./script.js"></script>
     </body>
 </html>

--- a/dars5/script.js
+++ b/dars5/script.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const barsIcon = document.querySelector('.bars-icon');
+  const siteNav = document.querySelector('.sitenav');
+
+  if (barsIcon && siteNav) {
+    barsIcon.addEventListener('click', () => {
+      siteNav.classList.toggle('menu-open');
+    });
+  }
+});
+


### PR DESCRIPTION
## Summary
- Add script to toggle navigation menu on smaller screens
- Include script reference in HTML to enable responsive menu interaction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c7e2819c83299dfe585e546b65e7